### PR TITLE
Fix failing to create latest_version.txt when non-ASCII character exists in AppDir

### DIFF
--- a/MikuMikuWorld/File.cpp
+++ b/MikuMikuWorld/File.cpp
@@ -191,6 +191,11 @@ namespace IO
 		return std::filesystem::exists(wPath);
 	}
 
+	bool File::exists(const std::wstring& path)
+	{
+		return std::filesystem::exists(path);
+	}
+
 	FileDialogResult FileDialog::showFileDialog(DialogType type, DialogSelectType selectType)
 	{
 		std::wstring wTitle = mbToWideStr(title);

--- a/MikuMikuWorld/File.h
+++ b/MikuMikuWorld/File.h
@@ -26,6 +26,7 @@ namespace IO
 		static std::string getFilepath(const std::string& filename);
 		static std::string fixPath(const std::string& path);
 		static bool exists(const std::string& path);
+		static bool exists(const std::wstring& path);
 
 		void open(const std::wstring& filename, const wchar_t* mode);
 		void open(const std::string& filename, const char* mode);

--- a/MikuMikuWorld/ScoreEditor.cpp
+++ b/MikuMikuWorld/ScoreEditor.cpp
@@ -69,12 +69,12 @@ namespace MikuMikuWorld
 	void ScoreEditor::fetchUpdate()
 	{
 
-		std::string updateFlagPath = Application::getAppDir() + "latest_version.txt";
+		std::wstring updateFlagPath = IO::mbToWideStr(Application::getAppDir() + "latest_version.txt");
 		bool shouldFetchUpdate = true;
 		std::string latestVersionString;
 		if (IO::File::exists(updateFlagPath))
 		{
-			auto file = IO::File(updateFlagPath, "r");
+			auto file = IO::File(updateFlagPath, L"r");
 			auto lastWriteTime = file.getLastWriteTime();
 			auto now = std::chrono::system_clock::now();
 			auto diff =
@@ -109,7 +109,7 @@ namespace MikuMikuWorld
 				latestVersionString = tagName.substr(1);
 			}
 
-			auto file = IO::File(updateFlagPath, "w");
+			auto file = IO::File(updateFlagPath, L"w");
 			file.write(latestVersionString);
 			file.flush();
 			file.close();


### PR DESCRIPTION
The original code uses a "narrow-string" version of `IO::File` to open `updateFlagPath` (latest_version.txt), which returns a null pointer when `updateFlagPath` contains non-ASCII characters.
This problem is found in version v3.2.1.28, and crashes it when it performs the update check.