### PR TITLE
Fix translation files not loaded when run under non-ASCII path

### DIFF
--- a/MikuMikuWorld/File.cpp
+++ b/MikuMikuWorld/File.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <ctime>
 #include <stdio.h>
+#include <iostream>
 #include <stdlib.h>
 #include <filesystem>
 #include <chrono>
@@ -32,14 +33,15 @@ namespace IO
 			close();
 
 		stream = _wfopen(filename.c_str(), mode);
+		if (!stream)
+			std::wcerr << L"Failed to open file: " << filename << std::endl;
 	}
 
 	void File::open(const std::string& filename, const char* mode)
 	{
-		if (stream)
-			close();
-
-		stream = fopen(filename.c_str(), mode);
+		std::wstring wFileName = mbToWideStr(filename);
+		std::wstring wMode(mode, mode + strlen(mode));
+		open(wFileName, wMode.c_str());
 	}
 
 	void File::close()


### PR DESCRIPTION
Similar to PR #37, this time `Language::read` invokes the "narrow-string" version of `File()` and fails when `filename` contains non-ASCII characters:
```cpp
void Language::read(const std::string& filename)
{
	if (!File::exists(filename))
		return;

	File f(filename, "r, ccs=UNICODE"); // <----
	std::vector<std::string> lines = f.readAllLines();

	...
}
```

I prefer linking the "narrow version" of `File::open` to its wide version this time,  so that we won't get into this kind of annoying problem again no matter which version of `File()` is used in the future.