### PR TITLE
Fix update available dialog not displaying latest version

### DIFF
--- a/MikuMikuWorld/ScoreEditor.cpp
+++ b/MikuMikuWorld/ScoreEditor.cpp
@@ -136,6 +136,7 @@ namespace MikuMikuWorld
 			if (latestVersionPart > currentVersionPart)
 			{
 				std::cout << "Update available" << std::endl;
+				updateAvailableDialog.latestVersion = latestVersionString;
 				updateAvailableDialog.open = true;
 				return;
 			}


### PR DESCRIPTION
Currently, `UpdateAvailableDialog::latestVersion` is displayed in the update available dialog but never assigned a value. This prevents the dialog from displaying the latest version:

![1726057735778](https://github.com/user-attachments/assets/a53a7073-00a1-444d-8dd0-bae7da9c7281)

This pull request assigns `latestVersionString` to it upon opening the dialog, so that the latest version can be correctly displayed.